### PR TITLE
Add `client.close()`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -109,6 +109,13 @@ class LimitdRedis extends EventEmitter {
   reset(type, key, opts, cb) {
     this.put(type, key, opts, cb);
   }
+
+  close(callback) {
+    this.db.close((err) => {
+      this.db.removeAllListeners();
+      callback(err);
+    });
+  }
 }
 
 module.exports = LimitdRedis;

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -161,4 +161,15 @@ describe('LimitdRedis', () => {
       client.reset('test', 'test', 1, done);
     });
   });
+
+  describe('#close', () => {
+    it('should call db.close', (done) => {
+      client.db.close = (cb) => cb();
+      client.close((err) => {
+        assert.equal(client.db.listenerCount('error'), 0);
+        assert.equal(client.db.listenerCount('ready'), 0);
+        done(err);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Supports closing the `db` and cleaning up `client`'s event listeners.