### PR TITLE
Add `resetAll()` method to clear all keys of all buckets

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -109,6 +109,10 @@ class LimitdRedis extends EventEmitter {
   reset(type, key, opts, cb) {
     this.put(type, key, opts, cb);
   }
+
+  resetAll(cb) {
+    this.db.resetAll(cb);
+  }
 }
 
 module.exports = LimitdRedis;

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,6 +1,7 @@
 const ms = require('ms');
 const fs = require('fs');
 const _ = require('lodash');
+const async = require('async');
 const utils = require('./utils');
 const Redis = require('ioredis');
 const EventEmitter = require('events').EventEmitter;
@@ -257,6 +258,19 @@ class LimitDBRedis extends EventEmitter {
           limit: bucketKeyConfig.size
         });
       });
+  }
+
+  /**
+   * Resets/re-fills all keys in all buckets.
+   * @param {function(Error)} [callback].
+   */
+  resetAll(callback) {
+    callback = callback || _.noop;
+
+    const dbs = this.redis.nodes ? this.redis.nodes('master') : [this.redis];
+    async.each(dbs, (db, cb) => {
+      db.flushall(cb);
+    }, callback);
   }
 }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -269,7 +269,7 @@ class LimitDBRedis extends EventEmitter {
 
     const dbs = this.redis.nodes ? this.redis.nodes('master') : [this.redis];
     async.each(dbs, (db, cb) => {
-      db.flushall(cb);
+      db.flushdb(cb);
     }, callback);
   }
 }

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -161,4 +161,11 @@ describe('LimitdRedis', () => {
       client.reset('test', 'test', 1, done);
     });
   });
+
+  describe('#resetAll', () => {
+    it('should call db.resetAll', (done) => {
+      client.db.resetAll = (cb) => cb();
+      client.resetAll(done);
+    });
+  });
 });


### PR DESCRIPTION
Also fixed some badly escaped regexps in tests.