### PR TITLE
Replace setImmediate with process.nextTick

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -144,7 +144,7 @@ class LimitDBRedis extends EventEmitter {
   take(params, callback) {
     const valError = this.validateParams(params, 'key');
     if (valError) {
-      return setImmediate(callback, valError);
+      return process.nextTick(callback, valError);
     }
 
     const bucket = this.buckets[params.type];
@@ -153,7 +153,7 @@ class LimitDBRedis extends EventEmitter {
     const count = params.count || 1;
 
     if (bucketKeyConfig.unlimited) {
-      return setImmediate(callback, null, {
+      return process.nextTick(callback, null, {
         conformant: true,
         remaining: bucketKeyConfig.size,
         reset: Math.ceil(Date.now() / 1000),
@@ -225,7 +225,7 @@ class LimitDBRedis extends EventEmitter {
 
     const valError = this.validateParams(params, 'key');
     if (valError) {
-      return setImmediate(callback, valError);
+      return process.nextTick(callback, valError);
     }
 
     const bucket = this.buckets[params.type];
@@ -235,7 +235,7 @@ class LimitDBRedis extends EventEmitter {
     count = Math.min(count, bucketKeyConfig.size);
 
     if (bucketKeyConfig.unlimited) {
-      return setImmediate(callback, null, {
+      return process.nextTick(callback, null, {
         remaining: bucketKeyConfig.size,
         reset: Math.ceil(Date.now() / 1000),
         limit: bucketKeyConfig.size


### PR DESCRIPTION
setImmediate runs after almost a whole event loop cycle (except close callbacks)
which means that what we put in setImmediate is affected by blocked "event loop
latency"; i.e. if anything between the point setImmediate is executed and the "check"
section of event loop blocks the event loop (for example one of the pending callbacks
in poll section), then latency of limiter will increase; even for the case of non-ratelimiting
(unlimited: true). This PR replaces setImmediate by process.nextTick, nextTick is executed
after current function but before the event loop is allowed to continue, providing a very low
latency for the case of not-rate-limit.